### PR TITLE
Pin GitHub Actions to latest release with SHA

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
     -
       name: Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
     -
       name: Running Yak analysis
       uses: ./


### PR DESCRIPTION
This PR pins GitHub Actions used in workflows to their latest release using SHA pinning for security best practices.

## Changes
- Pin `actions/checkout` from `v6` to `v6.0.1` (SHA: `8e8c483db84b4bee98b60c0593521ed34d9990e8`)
- Add human-readable version comments (`# v6.0.1`) after the pinned SHA for easier maintenance

## Benefits
- **Security**: Pinning to specific SHAs prevents potential supply chain attacks
- **Reproducibility**: Ensures consistent workflow behavior across runs
- **Dependabot Compatible**: Version comments allow Dependabot to automatically update these pins
- **Transparency**: Clear version comments make it easy to see what version is being used

Dependabot will be able to automatically create PRs to update these pinned versions in the future.